### PR TITLE
Read and send simulation type

### DIFF
--- a/simulation_server.py
+++ b/simulation_server.py
@@ -298,7 +298,7 @@ class Client:
                         client.websocket.write_message(error)
                         return
 
-                # create a docker-compose.yml and simulation type
+                # create a docker-compose.yml and get simulation type
                 dockerComposePath = ''
                 for yamlFileName in ['webots.yml', 'webots.yaml']:
                     if os.path.exists(yamlFileName):

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -298,7 +298,7 @@ class Client:
                         client.websocket.write_message(error)
                         return
 
-                # create a docker-compose.yml
+                # create a docker-compose.yml and simulation type
                 dockerComposePath = ''
                 for yamlFileName in ['webots.yml', 'webots.yaml']:
                     if os.path.exists(yamlFileName):
@@ -313,6 +313,9 @@ class Client:
                                     envVarDocker["THEIA_VOLUME"] = volume
                                     envVarDocker["THEIA_PORT"] = port + 500
                                     client.websocket.write_message('ide: enable')
+                            elif line.strip().startswith("type:"):
+                                message = line.replace(" ", "")
+                                client.websocket.write_message(message)
                         break
 
                 if not os.path.exists(dockerComposePath):


### PR DESCRIPTION
When we read the `webots.yml` file, we can extract the type of simulation and send it to `webotsJS` to show that the current simulation is a benchmark.