### PR TITLE
Allow python yaml loading

### DIFF
--- a/simulation_server.py
+++ b/simulation_server.py
@@ -307,7 +307,7 @@ class Client:
                         for line in data:
                             if line.startswith("dockerCompose:"):
                                 info = line.split(':')
-                                if info[1].startswith("theia"):
+                                if info[1].strip().startswith("theia"):
                                     volume = info[2]
                                     dockerComposePath = config['dockerConfDir'] + "/docker-compose-theia.yml"
                                     envVarDocker["THEIA_VOLUME"] = volume


### PR DESCRIPTION
The python `yaml` library used in animation recording actions requires the format of lines in `yaml` files to have a space after the first key using `yaml.load()`. For example:

`dockerCompose:theia:webots-project/controllers/move/`  (is not allowed)
`dockerCompose: theia:webots-project/controllers/move/`  (is allowed)

Therefore we remove leading and/or trailing empty characters at the beginning of reading strings to allow for compatibility with previously created `yaml` files