### PR TITLE
Fix quickstart example

### DIFF
--- a/config/simulation/local.json
+++ b/config/simulation/local.json
@@ -3,5 +3,6 @@
   "ssl": false,
   "portRewrite": false,
   "debug": true,
-  "webotsHome": "/usr/local/webots"
+  "webotsHome": "/usr/local/webots",
+  "allowedRepositories": "https://github.com/cyberbotics"
 }


### PR DESCRIPTION
Only the `allowedRepositories` are allowed to run on the metal, so it was broken the [quick-start example](https://www.cyberbotics.com/doc/guide/prerequisites-and-overview?version=master)