### PR TITLE
More loading info

### DIFF
--- a/simulation_server.py
+++ b/simulation_server.py
@@ -372,7 +372,7 @@ class Client:
                 if config['docker']:
                     if line:
                         logging.info(line)
-                        if not (defaultDockerfilePath or "theia" in line):
+                        if not ("theia" in line):
                             client.websocket.write_message(f'loading: {line}')
                         if defaultDockerfilePath and "not found" in line:
                             client.websocket.write_message(


### PR DESCRIPTION
When Thomas was testing the progress bar, he was not testing with the default image (the default image was not created at that time) so he had all the prints.

Remove the condition on `defaultDockerfilePath` is restoring the normal behavior of the progress bar.