### PR TITLE
New local starting server

### DIFF
--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -1,0 +1,74 @@
+import os
+import signal
+import socket
+import subprocess
+import sys
+from os import walk
+
+HOST = ""  # Any host can connect
+PORT = int(sys.argv[1])  # Port to listen on
+
+shared_folder = None
+webots = None
+
+def start_webots(connection):
+    #shared_folder_str = shared_folder.decode("utf-8")
+    filenames = next(walk(shared_folder), (None, None, []))[2]
+    worlds = list(filter(lambda file: file.endswith('.wbt'), filenames))
+
+    if(len(worlds) == 0):
+        return -1
+    if(len(worlds) > 1):
+        return -2
+    world_file = os.path.join(shared_folder, worlds[0])
+
+    arguments = []
+    lines = []
+    if 'launch_args.txt' in filenames:
+        launch_args_file = open(os.path.join(shared_folder, 'launch_args.txt'), 'r')
+        lines = launch_args_file.readlines()
+        for i in range(len(lines)):
+            lines[i] = lines[i].strip()
+
+    connection.sendall(b"ACK")
+    subprocess.call(['/usr/bin/open', '-W', '-n', '-a', '/Applications/Webots.app', '--args', world_file, *lines])
+
+    os.remove(world_file)
+    if 'launch_args.txt' in filenames:
+        os.remove(os.path.join(shared_folder, 'launch_args.txt'))
+
+    return 1
+
+def keyboardInterruptHandler(signal, frame):
+    if(shared_folder):
+        if(os.path.isdir(shared_folder)):
+            for filename in os.listdir(shared_folder):
+                filepath = os.path.join(shared_folder, filename)
+                if os.path.isfile(filepath):
+                    os.remove(filepath)
+    exit(0)
+
+signal.signal(signal.SIGINT, keyboardInterruptHandler)
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+    s.bind((HOST, PORT))
+    s.listen()
+    conn, addr = s.accept()
+    with conn:
+        print(f"Connected by {addr}")
+        while True:
+            data = conn.recv(1024)
+            if not data:
+                break
+            shared_folder = data.decode("utf-8")
+            success = start_webots(conn) if(os.path.isdir(shared_folder)) else 0
+            if success == 0:
+                conn.sendall(b"FAIL0")
+                print(f"The shared folder '{data_str}' doesn't exist.")
+            elif success == -1:
+                conn.sendall(b"FAIL1")
+                print(f"No world could be found in the shared folder.")
+            elif success == -2:
+                conn.sendall(b"FAIL2")
+                print(f"More than one world was found in the shared folder.")
+            elif success == 1:
+                print(f"Webots was executed successfully.")

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from os import walk
 
-HOST = ""  # Any host can connect
+HOST = ''  # Any host can connect
 PORT = int(sys.argv[1])  # Port to listen on
 
 shared_folder = None

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -72,4 +72,4 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 conn.sendall(b'FAIL2')
                 print('More than one world was found in the shared folder.' file=sys.stderr)
             elif success == 1:
-                print(f"Webots was executed successfully.")
+                print('Webots was executed successfully.')

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -48,6 +48,7 @@ def keyboardInterruptHandler(signal, frame):
                     os.remove(filepath)
     exit(0)
 
+
 signal.signal(signal.SIGINT, keyboardInterruptHandler)
 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
     s.bind((HOST, PORT))

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -17,6 +17,7 @@
 """Local simulation server."""
 
 import os
+import shutil
 import signal
 import socket
 import subprocess
@@ -60,10 +61,12 @@ def start_webots(connection):
 def keyboardInterruptHandler(signal, frame):
     if shared_folder:
         if os.path.isdir(shared_folder):
-            for filename in os.listdir(shared_folder):
-                filepath = os.path.join(shared_folder, filename)
-                if os.path.isfile(filepath):
-                    os.remove(filepath)
+            for element in os.listdir(shared_folder):
+                element_path = os.path.join(shared_folder, element)
+                if os.path.isfile(element_path):
+                    os.remove(element_path)
+                if os.path.isdir(element_path):
+                    shutil.rmtree(element_path)
     exit(0)
 
 

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -31,6 +31,17 @@ shared_folder = None
 webots = None
 
 
+def clean_shared_folder():
+    if shared_folder:
+        if os.path.isdir(shared_folder):
+            for element in os.listdir(shared_folder):
+                element_path = os.path.join(shared_folder, element)
+                if os.path.isfile(element_path):
+                    os.remove(element_path)
+                if os.path.isdir(element_path):
+                    shutil.rmtree(element_path)
+
+
 def start_webots(connection):
     filenames = next(walk(shared_folder), (None, None, []))[2]
     worlds = list(filter(lambda file: file.endswith('.wbt'), filenames))
@@ -51,22 +62,12 @@ def start_webots(connection):
     connection.sendall(b'ACK')
     subprocess.call(['/usr/bin/open', '-W', '-n', '-a', '/Applications/Webots.app', '--args', world_file, *lines])
 
-    os.remove(world_file)
-    if 'launch_args.txt' in filenames:
-        os.remove(os.path.join(shared_folder, 'launch_args.txt'))
-
+    clean_shared_folder()
     return 1
 
 
 def keyboardInterruptHandler(signal, frame):
-    if shared_folder:
-        if os.path.isdir(shared_folder):
-            for element in os.listdir(shared_folder):
-                element_path = os.path.join(shared_folder, element)
-                if os.path.isfile(element_path):
-                    os.remove(element_path)
-                if os.path.isdir(element_path):
-                    shutil.rmtree(element_path)
+    clean_shared_folder()
     exit(0)
 
 

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -13,7 +13,6 @@ webots = None
 
 
 def start_webots(connection):
-    #shared_folder_str = shared_folder.decode("utf-8")
     filenames = next(walk(shared_folder), (None, None, []))[2]
     worlds = list(filter(lambda file: file.endswith('.wbt'), filenames))
 

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -67,7 +67,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 print(f"The shared folder '{shared_folder}' doesn't exist.", file=sys.stderr)
             elif success == -1:
                 conn.sendall(b"FAIL1")
-                print(f"No world could be found in the shared folder.")
+                print('No world could be found in the shared folder.' file=sys.stderr)
             elif success == -2:
                 conn.sendall(b'FAIL2')
                 print(f"More than one world was found in the shared folder.")

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -22,7 +22,6 @@ def start_webots(connection):
         return -2
     world_file = os.path.join(shared_folder, worlds[0])
 
-    arguments = []
     lines = []
     if 'launch_args.txt' in filenames:
         launch_args_file = open(os.path.join(shared_folder, 'launch_args.txt'), 'r')

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -60,7 +60,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             data = conn.recv(1024)
             if not data:
                 break
-            shared_folder = data.decode("utf-8")
+            shared_folder = data.decode('utf-8')
             success = start_webots(conn) if(os.path.isdir(shared_folder)) else 0
             if success == 0:
                 conn.sendall(b"FAIL0")

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -70,6 +70,6 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 print('No world could be found in the shared folder.' file=sys.stderr)
             elif success == -2:
                 conn.sendall(b'FAIL2')
-                print(f"More than one world was found in the shared folder.")
+                print('More than one world was found in the shared folder.' file=sys.stderr)
             elif success == 1:
                 print(f"Webots was executed successfully.")

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -85,10 +85,10 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 message = f'FAIL: The shared folder \'{shared_folder}\' doesn\'t exist.'
                 conn.sendall(message.encode('utf-8'))
             elif success == -1:
-                message = "FAIL: No world could be found in the shared folder."
+                message = 'FAIL: No world could be found in the shared folder.'
                 conn.sendall(message.encode('utf-8'))
             elif success == -2:
-                message = "FAIL: More than one world was found in the shared folder."
+                message = 'FAIL: More than one world was found in the shared folder.'
                 conn.sendall(message.encode('utf-8'))
             if success == 1:
                 print('Webots was executed successfully.')

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -17,8 +17,6 @@
 """Local simulation server."""
 
 import os
-import shutil
-import signal
 import socket
 import subprocess
 import sys
@@ -31,31 +29,11 @@ shared_folder = None
 tcp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
 
-def clean_shared_folder():
-    if shared_folder:
-        if os.path.isdir(shared_folder):
-            for element in os.listdir(shared_folder):
-                element_path = os.path.join(shared_folder, element)
-                if os.path.isfile(element_path):
-                    os.remove(element_path)
-                if os.path.isdir(element_path):
-                    shutil.rmtree(element_path)
-
-
-def keyboardInterruptHandler(signal, frame):
-    clean_shared_folder()
-    tcp_socket.close()
-    exit(0)
-
-
 def print_and_exit(message):
-    clean_shared_folder()
     tcp_socket.close()
     print(message, file=sys.stderr)
     exit(1)
 
-
-signal.signal(signal.SIGINT, keyboardInterruptHandler)
 
 tcp_socket.bind((HOST, PORT))
 tcp_socket.listen()
@@ -100,7 +78,6 @@ while webots_process.poll() is None:
     else:
         if not data:
             print('Connection was closed by the client.')
-            clean_shared_folder()
             tcp_socket.close()
             webots_process.kill()
             exit(1)
@@ -108,5 +85,4 @@ while webots_process.poll() is None:
 print('Webots was executed successfully.')
 closing_message = 'CLOSED'
 connection.sendall(closing_message.encode('utf-8'))
-clean_shared_folder()
 tcp_socket.close()

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -29,7 +29,7 @@ def start_webots(connection):
         for i in range(len(lines)):
             lines[i] = lines[i].strip()
 
-    connection.sendall(b"ACK")
+    connection.sendall(b'ACK')
     subprocess.call(['/usr/bin/open', '-W', '-n', '-a', '/Applications/Webots.app', '--args', world_file, *lines])
 
     os.remove(world_file)

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -57,7 +57,7 @@ while True:
     try:
         webots_process = subprocess.Popen(cmd)
     except FileNotFoundError:
-        message = 'FAIL: Webots could not be found on the host.'
+        message = f'FAIL: \'{cmd[0]}\'could not be found on the host.'
         connection.sendall(message.encode('utf-8'))
         print(message, file=sys.stderr)
         connection.close()

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -71,6 +71,7 @@ signal.signal(signal.SIGINT, keyboardInterruptHandler)
 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
     s.bind((HOST, PORT))
     s.listen()
+    print(f'Waiting for connection on port {PORT}...')
     conn, addr = s.accept()
     with conn:
         print(f'Connection from {addr}')
@@ -79,15 +80,17 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             if not data:
                 break
             shared_folder = data.decode('utf-8')
-            success = start_webots(conn) if(os.path.isdir(shared_folder)) else 0
+            success = start_webots(conn) if os.path.isdir(shared_folder) else 0
             if success == 0:
-                conn.sendall(b'FAIL0')
-                print(f"The shared folder '{shared_folder}' doesn't exist.", file=sys.stderr)
+                message = f'FAIL: The shared folder \'{shared_folder}\' doesn\'t exist.'
+                conn.sendall(message.encode('utf-8'))
             elif success == -1:
-                conn.sendall(b"FAIL1")
-                print('No world could be found in the shared folder.' file=sys.stderr)
+                message = "FAIL: No world could be found in the shared folder."
+                conn.sendall(message.encode('utf-8'))
             elif success == -2:
-                conn.sendall(b'FAIL2')
-                print('More than one world was found in the shared folder.' file=sys.stderr)
-            elif success == 1:
+                message = "FAIL: More than one world was found in the shared folder."
+                conn.sendall(message.encode('utf-8'))
+            if success == 1:
                 print('Webots was executed successfully.')
+            else:
+                print(message, file=sys.stderr)

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -69,7 +69,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 conn.sendall(b"FAIL1")
                 print(f"No world could be found in the shared folder.")
             elif success == -2:
-                conn.sendall(b"FAIL2")
+                conn.sendall(b'FAIL2')
                 print(f"More than one world was found in the shared folder.")
             elif success == 1:
                 print(f"Webots was executed successfully.")

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -1,3 +1,21 @@
+#!/usr/bin/env python3
+
+# Copyright 1996-2022 Cyberbotics Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Local simulation server."""
+
 import os
 import signal
 import socket
@@ -16,9 +34,9 @@ def start_webots(connection):
     filenames = next(walk(shared_folder), (None, None, []))[2]
     worlds = list(filter(lambda file: file.endswith('.wbt'), filenames))
 
-    if(len(worlds) == 0):
+    if len(worlds) == 0:
         return -1
-    if(len(worlds) > 1):
+    if len(worlds) > 1:
         return -2
     world_file = os.path.join(shared_folder, worlds[0])
 
@@ -40,8 +58,8 @@ def start_webots(connection):
 
 
 def keyboardInterruptHandler(signal, frame):
-    if(shared_folder):
-        if(os.path.isdir(shared_folder)):
+    if shared_folder:
+        if os.path.isdir(shared_folder):
             for filename in os.listdir(shared_folder):
                 filepath = os.path.join(shared_folder, filename)
                 if os.path.isfile(filepath):

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -11,6 +11,7 @@ PORT = int(sys.argv[1])  # Port to listen on
 shared_folder = None
 webots = None
 
+
 def start_webots(connection):
     #shared_folder_str = shared_folder.decode("utf-8")
     filenames = next(walk(shared_folder), (None, None, []))[2]

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -63,7 +63,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             shared_folder = data.decode('utf-8')
             success = start_webots(conn) if(os.path.isdir(shared_folder)) else 0
             if success == 0:
-                conn.sendall(b"FAIL0")
+                conn.sendall(b'FAIL0')
                 print(f"The shared folder '{data_str}' doesn't exist.")
             elif success == -1:
                 conn.sendall(b"FAIL1")

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -59,7 +59,7 @@ while True:
         path_suffix = 'Contents/MacOS/webots' if sys.platform('darwin') else 'webots'
         command[0] = os.path.join(os.environ['WEBOTS_HOME'], path_suffix)
     else:
-        message = 'WEBOTS_HOME is not defined. Please define a valid Webots installation folder.'
+        message = 'FAIL: WEBOTS_HOME is not defined. Please define a valid Webots installation folder.'
         close_connection(connection, message)
         continue
 

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -36,38 +36,17 @@ while True:
 
     print(f'Connection from {address}')
     data = connection.recv(1024)
-    shared_folder = data.decode('utf-8')
-    if not os.path.isdir(shared_folder):
-        message = f'FAIL: The shared folder \'{shared_folder}\' doesn\'t exist.'
+    cmd = data.decode('utf-8').split(' ')
+
+    world_file = cmd[1]
+    if not os.path.isfile(world_file):
+        message = f'FAIL: The world file \'{world_file}\' doesn\'t exist.'
         connection.sendall(message.encode('utf-8'))
         print(message, file=sys.stderr)
         connection.close()
         continue
 
-    filenames = next(walk(shared_folder), (None, None, []))[2]
-    worlds = list(filter(lambda file: file.endswith('.wbt'), filenames))
-    if len(worlds) == 0:
-        message = 'FAIL: No world could be found in the shared folder.'
-        connection.sendall(message.encode('utf-8'))
-        print(message, file=sys.stderr)
-        connection.close()
-        continue
-    if len(worlds) > 1:
-        message = 'FAIL: More than one world was found in the shared folder.'
-        connection.sendall(message.encode('utf-8'))
-        print(message, file=sys.stderr)
-        connection.close()
-        continue
-    world_file = os.path.join(shared_folder, worlds[0])
-
-    lines = []
-    if 'launch_args.txt' in filenames:
-        launch_args_file = open(os.path.join(shared_folder, 'launch_args.txt'), 'r')
-        lines = launch_args_file.readlines()
-        for i in range(len(lines)):
-            lines[i] = lines[i].strip()
-
-    webots_process = subprocess.Popen(['/Applications/Webots.app/Contents/MacOS/webots', world_file, *lines])
+    webots_process = subprocess.Popen(cmd)
     connection.sendall(b'ACK')
     connection.settimeout(1)
     connection_closed = False

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -64,7 +64,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             success = start_webots(conn) if(os.path.isdir(shared_folder)) else 0
             if success == 0:
                 conn.sendall(b'FAIL0')
-                print(f"The shared folder '{data_str}' doesn't exist.")
+                print(f"The shared folder '{shared_folder}' doesn't exist.", file=sys.stderr)
             elif success == -1:
                 conn.sendall(b"FAIL1")
                 print(f"No world could be found in the shared folder.")

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -106,5 +106,7 @@ while webots_process.poll() is None:
             exit(1)
 
 print('Webots was executed successfully.')
+closing_message = 'CLOSED'
+connection.sendall(closing_message.encode('utf-8'))
 clean_shared_folder()
 tcp_socket.close()

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -56,10 +56,10 @@ while True:
     if os.path.isabs(command[0]):
         pass
     elif 'WEBOTS_HOME' in os.environ:
-        path_suffix = 'Contents/MacOS/webots' if sys.platform('darwin') else 'webots'
+        path_suffix = 'Contents/MacOS/webots' if sys.platform == 'darwin' else 'webots'
         command[0] = os.path.join(os.environ['WEBOTS_HOME'], path_suffix)
     else:
-        message = 'FAIL: WEBOTS_HOME is not defined. Please define a valid Webots installation folder.'
+        message = 'FAIL: WEBOTS_HOME environment variable is not defined. Please define a valid Webots installation folder.'
         close_connection(connection, message)
         continue
 

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -22,7 +22,7 @@ import subprocess
 import sys
 
 HOST = ''  # Any host can connect
-PORT = 2000  # Port to listen on
+PORT = 2000 if len(sys.argv) < 2 else int(sys.argv[1])  # Port to listen on
 
 
 def close_connection(connection, message):
@@ -36,8 +36,6 @@ tcp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 tcp_socket.bind((HOST, PORT))
 tcp_socket.listen()
 while True:
-    if len(sys.argv) >= 2:
-        PORT = sys.argv[1]
     print(f'Waiting for connection on port {PORT}...')
     connection, address = tcp_socket.accept()
 

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -38,6 +38,7 @@ def start_webots(connection):
 
     return 1
 
+
 def keyboardInterruptHandler(signal, frame):
     if(shared_folder):
         if(os.path.isdir(shared_folder)):

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -60,7 +60,16 @@ def start_webots(connection):
             lines[i] = lines[i].strip()
 
     connection.sendall(b'ACK')
-    subprocess.call(['/usr/bin/open', '-W', '-n', '-a', '/Applications/Webots.app', '--args', world_file, *lines])
+    p = subprocess.Popen(['/usr/bin/open', '-W', '-n', '-a', '/Applications/Webots.app', '--args', world_file, *lines])
+    try:
+        p.wait()
+    except KeyboardInterrupt:
+        try:
+            p.terminate()
+        except OSError:
+            pass
+        p.wait()
+    # subprocess.call(['/usr/bin/open', '-W', '-n', '-a', '/Applications/Webots.app', '--args', world_file, *lines])
 
     clean_shared_folder()
     return 1

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -55,7 +55,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
     s.listen()
     conn, addr = s.accept()
     with conn:
-        print(f"Connected by {addr}")
+        print(f'Connection from {addr}')
         while True:
             data = conn.recv(1024)
             if not data:

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -20,7 +20,6 @@ import os
 import socket
 import subprocess
 import sys
-from os import walk
 
 HOST = ''  # Any host can connect
 PORT = int(sys.argv[1])  # Port to listen on
@@ -58,7 +57,7 @@ while True:
     try:
         webots_process = subprocess.Popen(cmd)
     except FileNotFoundError:
-        message = f'FAIL: Webots could not be found on the host.'
+        message = 'FAIL: Webots could not be found on the host.'
         connection.sendall(message.encode('utf-8'))
         print(message, file=sys.stderr)
         connection.close()

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -63,13 +63,15 @@ while True:
         close_connection(connection, message)
         continue
 
+    invalid_world_file = False
     for argument in command:
         if argument.endswith('.wbt'):
-            world_file = argument
+            if not os.path.isfile(argument):
+                message = f'FAIL: The world file \'{argument}\' doesn\'t exist.'
+                close_connection(connection, message)
+                invalid_world_file = True
             break
-    if world_file and not os.path.isfile(world_file):
-        message = f'FAIL: The world file \'{world_file}\' doesn\'t exist.'
-        close_connection(connection, message)
+    if invalid_world_file:
         continue
 
     try:

--- a/local_simulation_server.py
+++ b/local_simulation_server.py
@@ -22,7 +22,7 @@ import subprocess
 import sys
 
 HOST = ''  # Any host can connect
-PORT = int(sys.argv[1])  # Port to listen on
+PORT = 2000  # Port to listen on
 
 
 def close_connection(connection, message):
@@ -36,6 +36,8 @@ tcp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 tcp_socket.bind((HOST, PORT))
 tcp_socket.listen()
 while True:
+    if len(sys.argv) >= 2:
+        PORT = sys.argv[1]
     print(f'Waiting for connection on port {PORT}...')
     connection, address = tcp_socket.accept()
 


### PR DESCRIPTION
This new simple server allows to start Webots from a remote machine. The world and startup parameters are given in a shared folder. 

This server is added for macOS compatibility of `webots_ros2`, so that the Docker container can start Webots on the host machine, but this server could also be used in other situations.