### PR TITLE
Update benchmark docker-compose to competition

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repository contains the files to be deployed on a server machine to run Webots simulations online.
 
-The documentation on how to set-up a Webots simulation server is provided in the [Webots user guide](https://cyberbotics.com/doc/guide/web-simulation).
+The documentation on how to set-up a Webots simulation server is provided in the [Webots user guide](https://cyberbotics.com/doc/guide/web-server).

--- a/config/simulation/cyberbotics2.json
+++ b/config/simulation/cyberbotics2.json
@@ -3,11 +3,13 @@
   "projectsDir": "/home/cyberbotics/streaming_projects",
   "logDir": "log/",
   "monitorLogEnabled": true,
-  "permanentImages": [
-    "stpedrazzi/opendr-on-webots-cloud",
-    "benjamindeleze/theia-test",
-    "leoduggan/webots.cloud-test",
-    "leoduggan/webots-test",
-    "cyberbotics/webots.cloud"
+  "persistantDockerImages": [
+    "cyberbotics/webots.cloud:R2023a-ubuntu20.04-numpy",
+    "cyberbotics/webots.cloud:R2023a-ubuntu20.04",
+    "cyberbotics/webots.cloud:R2022b-ubuntu20.04",
+    "stpedrazzi/opendr-on-webots-cloud:latest",
+    "benjamindeleze/theia-test:test3",
+    "leoduggan/webots.cloud-test:24-01-2023",
+    "leoduggan/webots-test:24-01-2023"
   ]
 }

--- a/config/simulation/cyberbotics2.json
+++ b/config/simulation/cyberbotics2.json
@@ -2,14 +2,5 @@
   "port": 3000,
   "projectsDir": "/home/cyberbotics/streaming_projects",
   "logDir": "log/",
-  "monitorLogEnabled": true,
-  "persistantDockerImages": [
-    "cyberbotics/webots.cloud:R2023a-ubuntu20.04-numpy",
-    "cyberbotics/webots.cloud:R2023a-ubuntu20.04",
-    "cyberbotics/webots.cloud:R2022b-ubuntu20.04",
-    "stpedrazzi/opendr-on-webots-cloud:latest",
-    "benjamindeleze/theia-test:test3",
-    "leoduggan/webots.cloud-test:24-01-2023",
-    "leoduggan/webots-test:24-01-2023"
-  ]
+  "monitorLogEnabled": true
 }

--- a/config/simulation/cyberbotics2.json
+++ b/config/simulation/cyberbotics2.json
@@ -2,5 +2,12 @@
   "port": 3000,
   "projectsDir": "/home/cyberbotics/streaming_projects",
   "logDir": "log/",
-  "monitorLogEnabled": true
+  "monitorLogEnabled": true,
+  "permanentImages": [
+    "stpedrazzi/opendr-on-webots-cloud",
+    "benjamindeleze/theia-test",
+    "leoduggan/webots.cloud-test",
+    "leoduggan/webots-test",
+    "cyberbotics/webots.cloud"
+  ]
 }

--- a/config/simulation/docker/docker-compose-competition.yml
+++ b/config/simulation/docker/docker-compose-competition.yml
@@ -44,7 +44,6 @@ services:
       dockerfile: Dockerfile
       args:
         - WEBOTS_CONTROLLER_URL=tcp://172.17.0.1:$PORT/participant
-        - PORT=$PORT
         - PROJECT_PATH=$PROJECT_PATH
     command: python3 $PROJECT_PATH/remote_controller_launcher.py
     deploy:

--- a/config/simulation/docker/docker-compose-competition.yml
+++ b/config/simulation/docker/docker-compose-competition.yml
@@ -38,7 +38,6 @@ services:
   controller:
     depends_on:
       - webots
-    restart: 'unless-stopped' # restarts the container if the simulation is reset
     build:
       context: ./controllers
       dockerfile: Dockerfile

--- a/config/simulation/docker/docker-compose-competition.yml
+++ b/config/simulation/docker/docker-compose-competition.yml
@@ -63,6 +63,8 @@ services:
       - controller_data:$PROJECT_PATH/$THEIA_VOLUME:rw
 
   theia:
+    depends_on:
+      - controller
     image: benjamindeleze/theia-test:test3
     ports:
       - $THEIA_PORT:3000

--- a/config/simulation/docker/docker-compose-competition.yml
+++ b/config/simulation/docker/docker-compose-competition.yml
@@ -40,10 +40,10 @@ services:
       - webots
     restart: 'unless-stopped' # restarts the container if the simulation is reset
     build:
-      context: .
-      dockerfile: controller_Dockerfile
+      context: ./controllers
+      dockerfile: Dockerfile
       args:
-        - DEFAULT_CONTROLLER=$DEFAULT_CONTROLLER
+        - WEBOTS_CONTROLLER_URL=tcp://172.17.0.1:$PORT/participant
         - PORT=$PORT
         - PROJECT_PATH=$PROJECT_PATH
     command: python3 $PROJECT_PATH/remote_controller_launcher.py
@@ -61,7 +61,7 @@ services:
       - WEBOTS_STDOUT_REDIRECT=1
       - WEBOTS_STDERR_REDIRECT=1
     volumes:
-      - controller_data:$PROJECT_PATH/controllers/$DEFAULT_CONTROLLER:rw
+      - controller_data:$PROJECT_PATH/$THEIA_VOLUME:rw
 
   theia:
     image: benjamindeleze/theia-test:test3

--- a/config/simulation/docker/remote_controller_launcher.py
+++ b/config/simulation/docker/remote_controller_launcher.py
@@ -1,23 +1,23 @@
 import importlib.util
-import os
 from controller.wb import wb
 
 
 class Initializer:
     def __init__(self):
-        # Running wb_robot_init() before controller execution to send the logs to webots container stdout even if the controller crashes.
+        # Running wb_robot_init() before controller execution to send the logs
+        # to the webots container stdout even if the controller crashes.
         wb.wb_robot_init()
 
     def __del__(self):
         # If the controller crashed, we maintain the connection up.
-        # This is done to prevent the console from being spammed with error loop from docker re-opening endlessly a bugged controller.
+        # This is done to prevent the console from being spammed
+        # with an error message loop caused by docker re-opening endlessly a bugged controller.
         while wb.wb_robot_step(0) != -1:
             pass
 
 
 init = Initializer()
 
-default_controller = os.environ['DEFAULT_CONTROLLER']
-spec = importlib.util.spec_from_file_location(default_controller, f'{default_controller}.py')
+spec = importlib.util.spec_from_file_location('participant', 'participant.py')
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -386,6 +386,7 @@ class Client:
                 line = client.webots_process.stdout.readline().rstrip()
                 if config['docker']:
                     if line:
+                        logging.info(line)
                         if not ("theia" in line):
                             client.websocket.write_message(f'loading: {line}')
                         if defaultDockerfilePath and "not found" in line:

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -453,6 +453,31 @@ class Client:
                 self.webots_process = None
 
             # remove dangling images, stopped containers, build cache, volumes and networks
+            # Get list of all images
+            output = subprocess.check_output(['docker', 'images', '-a', '--format', '{{json . }}'])
+            output = output.decode()
+
+            # Split output into individual JSON objects
+            image_strings = output.strip().split('\n')
+            images = []
+            for image_string in image_strings:
+                images.append(json.loads(image_string))
+
+            current_time = time.time()
+
+            for image in images:
+                repository = image['Repository']
+                created_at = image['CreatedAt']
+                image_id = image['ID']
+                created_at = time.mktime(time.strptime(created_at, '%Y-%m-%d %H:%M:%S %z %Z'))
+
+                # Check if image is not in use by any running containers
+                output = subprocess.check_output(['docker', 'ps', '-q', '-f', f'ancestor={image_id}'])
+                # enhancement: use "if not any(fnmatch.fnmatch(repository, pattern) for pattern in config['permanentImages']):"
+                # to allow '*' wildcards in the config file e.g. "cyberbotics/*"
+                if output == b'' and current_time - created_at > 86400 and repository not in config['permanentImages']:
+                    subprocess.call(['docker', 'rmi', image_id])
+
             os.system("docker system prune --volumes -f")
         else:
             if self.webots_process:

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -408,12 +408,13 @@ class Client:
                 if client.webots_process is None:
                     break
                 line = line.rstrip()
+                logging.info('Read line: ' + line)
                 if line == 'pause':
                     client.idle = True
                 elif line == 'real-time' or line == 'step':
                     client.idle = False
                 elif client.competition and line == 'reset':
-                    print('Restarting controller...')
+                    logging.info('Restarting controller...')
                     subprocess.run([
                         'docker-compose', '-f', f'{self.project_instance_path}/docker-compose.yml',
                         'restart', 'controller'])

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -396,11 +396,12 @@ class Client:
                         line = line[line.index('|') + 2:]
                 if line.startswith('.'):  # Webots world is loaded, ready to receive connections
                     logging.info('Webots world is loaded, ready to receive connections')
+                    # TODO: doesn't work. Need to do this when a step or a real-time is printed by Webots when running
                     # if it is a competition docker project we restart the controller docker-compose service
                     # to reset the connection attempt and to connect directly:
                     if dockerComposePath == config['dockerConfDir'] + "/docker-compose-competition.yml":
                         subprocess.Popen([
-                            'docker-compose', '-f', f'{self.project_instance_path}/docker-compose-competition.yml',
+                            'docker-compose', '-f', f'{self.project_instance_path}/docker-compose.yml',
                             'restart', 'controller'])
                     break
             hostname = config['server']

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -324,10 +324,10 @@ class Client:
                                     envVarDocker["THEIA_VOLUME"] = volume
                                     envVarDocker["THEIA_PORT"] = port + 500
                                     client.websocket.write_message('ide: enable')
-                                elif info[1].strip() == 'default_controller':
-                                    default_controller = info[2]
-                                    dockerComposePath = config['dockerConfDir'] + "/docker-compose-benchmark.yml"
-                                    envVarDocker["DEFAULT_CONTROLLER"] = default_controller
+                                elif info[1].strip() == 'competition':
+                                    volume = info[2]
+                                    dockerComposePath = config['dockerConfDir'] + "/docker-compose-competition.yml"
+                                    envVarDocker["THEIA_VOLUME"] = volume
                                     envVarDocker["THEIA_PORT"] = port + 500
                                     client.websocket.write_message('ide: enable')
                                     # using hard link so that the COPY command in the Dockerfile will work on the launcher file

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -464,6 +464,7 @@ class Client:
                 images.append(json.loads(image_string))
 
             current_time = time.time()
+            print('Current time: ', current_time)
 
             for image in images:
                 repository = image['Repository']
@@ -471,10 +472,11 @@ class Client:
                 created_at = image['CreatedAt']
                 image_id = image['ID']
                 created_at = time.mktime(time.strptime(created_at, '%Y-%m-%d %H:%M:%S %z %Z'))
+                print(f'{repository}:{tag} {created_at} {image_id}')
 
                 # Check if image is not in use by any running containers
                 output = subprocess.check_output(['docker', 'ps', '-q', '-f', f'ancestor={image_id}'])
-                if (output == b'' and current_time - created_at > 86400
+                if (output == b'' and (current_time - created_at) > 86400
                         and f'{repository}:{tag}' not in config['persistantDockerImages']):
                     subprocess.call(['docker', 'rmi', image_id])
 

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -462,9 +462,7 @@ class Client:
             images = []
             for image_string in image_strings:
                 images.append(json.loads(image_string))
-
             current_time = time.time()
-            print('Current time: ', current_time)
 
             for image in images:
                 repository = image['Repository']
@@ -472,11 +470,9 @@ class Client:
                 created_at = image['CreatedAt']
                 image_id = image['ID']
                 created_at = time.mktime(time.strptime(created_at, '%Y-%m-%d %H:%M:%S %z %Z'))
-                print(f'{repository}:{tag} {created_at} {image_id}')
-
-                # Check if image is not in use by any running containers
+                # Check if image is not in use by any running containers and if it was created more than 24 hours ago
                 output = subprocess.check_output(['docker', 'ps', '-q', '-f', f'ancestor={image_id}'])
-                if (output == b'' and (current_time - created_at) > 86400
+                if (output == b'' and (current_time - created_at) > 24 * 60 * 60
                         and f'{repository}:{tag}' not in config['persistantDockerImages']):
                     subprocess.call(['docker', 'rmi', image_id])
 

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -439,7 +439,8 @@ class Client:
         """Force the termination of Webots or relative Docker service(s)."""
         if config['docker']:
             if os.path.exists(f"{self.project_instance_path}/docker-compose.yml"):
-                os.system(f"docker-compose -f {self.project_instance_path}/docker-compose.yml down -v --rmi all")
+                os.system(f"docker-compose -f {self.project_instance_path}/docker-compose.yml down "
+                          "-v --rmi local")
 
             if self.webots_process:
                 self.webots_process.terminate()
@@ -452,6 +453,7 @@ class Client:
 
             """# remove unused _webots images
             # TODO: could we do this with docker-compose down --rmi?
+            # We can, but it also removes the theia editor image
             available_images = os.popen(
                 "docker images --filter=reference='*_webots:*' --format '{{.Repository}}'").read().split('\n')
             running_images = os.popen("docker ps --format '{{.Image}}'").read().split('\n')

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -396,6 +396,12 @@ class Client:
                         line = line[line.index('|') + 2:]
                 if line.startswith('.'):  # Webots world is loaded, ready to receive connections
                     logging.info('Webots world is loaded, ready to receive connections')
+                    # if it is a competition docker project we restart the controller docker-compose service
+                    # to reset the connection attempt and to connect directly:
+                    if dockerComposePath == config['dockerConfDir'] + "/docker-compose-competition.yml":
+                        subprocess.Popen([
+                            'docker-compose', '-f', f'{self.project_instance_path}/docker-compose-competition.yml',
+                            'restart', 'controller'])
                     break
             hostname = config['server']
             protocol = 'wss:' if config['ssl'] else 'ws:'

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -384,7 +384,6 @@ class Client:
                     # client connection closed or killed
                     return
                 line = client.webots_process.stdout.readline().rstrip()
-                logging.info('Read line at startup: ' + line)
                 if config['docker']:
                     if line:
                         if not ("theia" in line):
@@ -408,15 +407,15 @@ class Client:
                 if client.webots_process is None:
                     break
                 line = line.rstrip()
-                if line == '.':
-                    client.websocket.write_message('.')
-                elif line.startswith('webots_1'):
-                    if line.endswith('| pause'):
+                if line.startswith('webots_1'):  # output from docker-compose's webots service
+                    output = line[line.index('|') + 2:]
+                    if output == '.':
+                        client.websocket.write_message('.')
+                    elif output == 'pause':
                         client.idle = True
-                    elif line.endswith('| real-time') or line.endswith('| step'):
+                    elif output == 'real-time' or output == 'step':
                         client.idle = False
-                    elif client.competition and line.endswith('| reset'):
-                        logging.info('Restarting controller...')
+                    elif client.competition and output == 'reset':
                         subprocess.Popen([
                             'docker-compose', '-f', f'{self.project_instance_path}/docker-compose.yml',
                             'restart', '--timeout', '0', 'controller'])

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -384,6 +384,7 @@ class Client:
                     # client connection closed or killed
                     return
                 line = client.webots_process.stdout.readline().rstrip()
+                logging.info('Read line at startup: ' + line)
                 if config['docker']:
                     if line:
                         logging.info(line)

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -409,11 +409,11 @@ class Client:
                     break
                 line = line.rstrip()
                 logging.info('Read line: ' + line)
-                if line == 'pause':
+                if line == 'webots_1      | pause':
                     client.idle = True
-                elif line == 'real-time' or line == 'step':
+                elif line == 'webots_1      | real-time' or line == 'webots_1      | step':
                     client.idle = False
-                elif client.competition and line == 'reset':
+                elif client.competition and line == 'webots_1      | reset':
                     logging.info('Restarting controller...')
                     subprocess.run([
                         'docker-compose', '-f', f'{self.project_instance_path}/docker-compose.yml',

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -387,7 +387,6 @@ class Client:
                 logging.info('Read line at startup: ' + line)
                 if config['docker']:
                     if line:
-                        logging.info(line)
                         if not ("theia" in line):
                             client.websocket.write_message(f'loading: {line}')
                         if defaultDockerfilePath and "not found" in line:
@@ -409,7 +408,6 @@ class Client:
                 if client.webots_process is None:
                     break
                 line = line.rstrip()
-                logging.info('Read line: ' + line)
                 if line == 'webots_1      | pause':
                     client.idle = True
                 elif line == 'webots_1      | real-time' or line == 'webots_1      | step':

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -296,7 +296,7 @@ class Client:
                     envVarDocker["DISPLAY"] = display
                     envVarDocker["XAUTHORITY"] = xauth
 
-                config['dockerConfDir'] = os.path.abspath(os.path.dirname( __file__)) + '/config/simulation/docker'
+                config['dockerConfDir'] = os.path.abspath(os.path.dirname(__file__)) + '/config/simulation/docker'
                 # create a Dockerfile if not provided in the project folder
                 defaultDockerfilePath = ''
                 if not os.path.isfile('Dockerfile'):

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -467,15 +467,15 @@ class Client:
 
             for image in images:
                 repository = image['Repository']
+                tag = image['Tag']
                 created_at = image['CreatedAt']
                 image_id = image['ID']
                 created_at = time.mktime(time.strptime(created_at, '%Y-%m-%d %H:%M:%S %z %Z'))
 
                 # Check if image is not in use by any running containers
                 output = subprocess.check_output(['docker', 'ps', '-q', '-f', f'ancestor={image_id}'])
-                # enhancement: use "if not any(fnmatch.fnmatch(repository, pattern) for pattern in config['permanentImages']):"
-                # to allow '*' wildcards in the config file e.g. "cyberbotics/*"
-                if output == b'' and current_time - created_at > 86400 and repository not in config['permanentImages']:
+                if (output == b'' and current_time - created_at > 86400
+                        and f'{repository}:{tag}' not in config['persistantDockerImages']):
                     subprocess.call(['docker', 'rmi', image_id])
 
             os.system("docker system prune --volumes -f")

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -413,7 +413,8 @@ class Client:
                 elif line == 'real-time' or line == 'step':
                     client.idle = False
                 elif client.competition and line == 'reset':
-                    subprocess.Popen([
+                    print('Restarting controller...')
+                    subprocess.run([
                         'docker-compose', '-f', f'{self.project_instance_path}/docker-compose.yml',
                         'restart', 'controller'])
                 elif line == '.':

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -249,7 +249,7 @@ class Client:
 
     def cleanup_webots_instance(self):
         """Cleanup the local Webots project not used any more by the client."""
-        if id(self):
+        if id(self) and os.path.exists(config['instancesPath'] + str(id(self))):
             shutil.rmtree(config['instancesPath'] + str(id(self)))
 
     def start_webots(self, on_webots_quit):

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -332,6 +332,11 @@ class Client:
                                     client.websocket.write_message('ide: enable')
                                     # using hard link so that the COPY command in the Dockerfile will work on the launcher file
                                     os.system(f'ln {config["dockerConfDir"]}/remote_controller_launcher.py')
+                                    with open(world, 'r') as world_file:
+                                        world_content = world_file.read()
+                                    world_content = world_content.replace('controller "participant"', 'controller "<extern>"')
+                                    with open(world, 'w') as world_file:
+                                        world_file.write(world_content)
                             elif line.strip().startswith("type:"):
                                 message = line.replace(" ", "")
                                 client.websocket.write_message(message)

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -440,7 +440,7 @@ class Client:
         if config['docker']:
             if os.path.exists(f"{self.project_instance_path}/docker-compose.yml"):
                 os.system(f"docker-compose -f {self.project_instance_path}/docker-compose.yml down "
-                          "-v --rmi local")
+                          "-v --rmi local --timeout 0")
 
             if self.webots_process:
                 self.webots_process.terminate()
@@ -452,13 +452,10 @@ class Client:
                 self.webots_process = None
 
             """# remove unused _webots images
-            # TODO: could we do this with docker-compose down --rmi?
-            # We can, but it also removes the theia editor image
             available_images = os.popen(
                 "docker images --filter=reference='*_webots:*' --format '{{.Repository}}'").read().split('\n')
             running_images = os.popen("docker ps --format '{{.Image}}'").read().split('\n')
             unused_images = ' '.join([i for i in available_images if i not in running_images])
-            # TODO: remove the controller images as well
             if unused_images:
                 os.system(f"docker image rm {unused_images}")"""
             # remove dangling images, stopped containers, build cache, volumes and networks


### PR DESCRIPTION
This PR updates the docker-compose file defined for benchmarks and adapts it to the new competition format.

It launches Webots and the competitor's controller in separate containers. When the participant reset the simulation after they edited the controller, the script uses the 'reset' signal form https://github.com/cyberbotics/webots/pull/5773 to restart the controller service.

It also fixes the idle count on the server monitor.

A new "persistantDockerImages" mechanism has been introduced: When a simulation session finishes, there is a cleaning step that removes all images that were created more than 24h ago that are not in the "persistantDockerImages" list of the json configuration file for simulations.

You can test it [here](https://benchmark.webots.cloud/run?version=R2023a&url=https%3A%2F%2Fgithub.com%2FJean-Eudes-le-retour%2Frobot-programming-benchmark%2Fblob%2Fmain%2Fworlds%2Frobot_programming.wbt&type=competition&context=try)