### PR TITLE
Improve load on session

### DIFF
--- a/session_server.py
+++ b/session_server.py
@@ -32,7 +32,7 @@ import tornado.websocket
 import traceback
 from urllib.request import urlopen, URLError
 
-LOAD_THRESHOLD = 99  # disable a simulation server when its load is 99% or more
+LOAD_THRESHOLD = 95  # disable a simulation server when its load is 99% or more
 LOAD_REFRESH = 5  # query load of simulation servers every 5 seconds
 
 availability = False


### PR DESCRIPTION
Changes:

- The load threshold is now 95% instead of 99%, this is because we do not know how much resources the next simulation will take but it could be more than one percent. And it is better to be cautious about that because if the server reached 100% memory, it will crash all the running instances, and we do no want that to happen.
- The simulation sends the average load of the 5 last seconds to the session server. This is done to minimize the chance that the session server refuses new connection on a temporary spike (especially when several connections tried to opened at once). It does not completely remove the problem but minimize it.

Illustration of those spikes (I don't know where they come from):
![Screenshot from 2023-02-01 14-29-09](https://user-images.githubusercontent.com/25938827/216615464-2335a78e-4c40-418d-a72c-40bd1514db1a.png)

Note that the current load is still visible on the monitor page.

- The current load is calculated as follow: 
```max(cpu_load, (swap.percent + memory.percent + gpu_load_memory) / 3, gpu_load_compute)```
To know if a server can accept another simulation, taking the `swap.percent` would be enough (no need for the `memory.percent` and `gpu_load_memory`). However if the session server needs to do some load balancing between different simulation servers it needs to have an idea of the current load of each simulation server. If they send only the swap, the session server will see a difference only once both the GPU and CPU RAM are saturated. 