### PR TITLE
Better Docker image pruning

### DIFF
--- a/simulation_server.py
+++ b/simulation_server.py
@@ -455,7 +455,7 @@ class Client:
             # Remove old images if there is a 'persistantDockerImages' list in the config file
             if 'persistantDockerImages' in config:
                 # Get list of all images
-                output = subprocess.check_output(['docker', 'images', '-a', '--format', '{{json . }}'])
+                output = subprocess.check_output(['docker', 'images', '--format', '{{json . }}'])
                 output = output.decode()
 
                 # Split output into individual JSON objects
@@ -469,13 +469,12 @@ class Client:
                     repository = image['Repository']
                     tag = image['Tag']
                     created_at = image['CreatedAt']
-                    image_id = image['ID']
                     created_at = time.mktime(time.strptime(created_at, '%Y-%m-%d %H:%M:%S %z %Z'))
                     # Check if image is not in use by any running containers and if it was created more than 24 hours ago
-                    output = subprocess.check_output(['docker', 'ps', '-q', '-f', f'ancestor={image_id}'])
-                    if (output == b'' and (current_time - created_at) > 2 * 24 * 60 * 60
+                    output = subprocess.check_output(['docker', 'ps', '-q', '-f', f'ancestor={repository}'])
+                    if (output == b'' and (current_time - created_at) > 5 * 60
                             and f'{repository}:{tag}' not in config['persistantDockerImages']):
-                        subprocess.call(['docker', 'rmi', image_id])
+                        subprocess.call(['docker', 'rmi', f'{repository}:{tag}'])
             os.system("docker system prune --volumes -f")
         else:
             if self.webots_process:

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -441,7 +441,7 @@ class Client:
         if config['docker']:
             if os.path.exists(f"{self.project_instance_path}/docker-compose.yml"):
                 os.system(f"docker-compose -f {self.project_instance_path}/docker-compose.yml down "
-                          "-v --rmi local --timeout 0")
+                          "-v --timeout 0")
 
             if self.webots_process:
                 self.webots_process.terminate()
@@ -473,7 +473,7 @@ class Client:
                     created_at = time.mktime(time.strptime(created_at, '%Y-%m-%d %H:%M:%S %z %Z'))
                     # Check if image is not in use by any running containers and if it was created more than 24 hours ago
                     output = subprocess.check_output(['docker', 'ps', '-q', '-f', f'ancestor={image_id}'])
-                    if (output == b'' and (current_time - created_at) > 24 * 60 * 60
+                    if (output == b'' and (current_time - created_at) > 2 * 24 * 60 * 60
                             and f'{repository}:{tag}' not in config['persistantDockerImages']):
                         subprocess.call(['docker', 'rmi', image_id])
             os.system("docker system prune --volumes -f")

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -472,7 +472,7 @@ class Client:
                     created_at = time.mktime(time.strptime(created_at, '%Y-%m-%d %H:%M:%S %z %Z'))
                     # Check if image is not in use by any running containers and if it was created more than 24 hours ago
                     output = subprocess.check_output(['docker', 'ps', '-q', '-f', f'ancestor={repository}'])
-                    if (output == b'' and (current_time - created_at) > 5 * 60
+                    if (output == b'' and (current_time - created_at) > 2 * 24 * 60 * 60
                             and f'{repository}:{tag}' not in config['persistantDockerImages']):
                         subprocess.call(['docker', 'rmi', f'{repository}:{tag}'])
             os.system("docker system prune --volumes -f")

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -471,7 +471,7 @@ class Client:
                     created_at = image['CreatedAt']
                     created_at = time.mktime(time.strptime(created_at, '%Y-%m-%d %H:%M:%S %z %Z'))
                     # Check if image is not in use by any running containers and if it was created more than 24 hours ago
-                    output = subprocess.check_output(['docker', 'ps', '-q', '-f', f'ancestor={repository}'])
+                    output = subprocess.check_output(['docker', 'ps', '-q', '-f', f'ancestor={repository}:{tag}'])
                     if (output == b'' and (current_time - created_at) > 2 * 24 * 60 * 60
                             and f'{repository}:{tag}' not in config['persistantDockerImages']):
                         subprocess.call(['docker', 'rmi', f'{repository}:{tag}'])


### PR DESCRIPTION
This PR finally makes the pruning work as intended.

The problem was that the built images were directly deleted after a simulation was stopped so they wouldn't stay in the cache.

I also set the 'keeping time' to two days as it seems more practical.