### PR TITLE
Enhancement replace svn with sparse checkout

### DIFF
--- a/simulation_server.py
+++ b/simulation_server.py
@@ -211,9 +211,9 @@ class Client:
         # We only clone the given version of the repository.
         # We checkout everything except the storage folder to speed up the clone.
         if folder:
-            sparse_set_command = f'git sparse-checkout set "/{folder}" "!/{folder}/storage/"'
+            sparse_set_command = f'git sparse-checkout set "/{folder}"'
         else:
-            sparse_set_command = 'git sparse-checkout set "/*" "!/storage/"'
+            sparse_set_command = 'echo "No need to set sparse checkout"'
         command = AsyncProcess([
             'bash', '-c',
             f'git clone --depth=1 --no-checkout --branch "{version}" "{repository_url}" && '

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -184,6 +184,7 @@ class Client:
                 error = f'Missing blob in Webots simulation URL, founds {parts[2]}'
             else:
                 version = parts[3]  # tag or branch name
+                folder = '/'.join(parts[4:length - 2])
                 if parts[length - 2] != 'worlds':
                     error = 'Missing worlds folder in Webots simulation URL'
                 else:
@@ -212,7 +213,7 @@ class Client:
             f'git clone --depth=1 --no-checkout --branch "{version}" "{repository_url}" && '
             f'cd "{repository}" && '
             # We checkout everything except the storage folder to speed up the clone.
-            'git sparse-checkout set "/*" "!/storage/" && '
+            f'git sparse-checkout set "/{folder if folder else "*"}" "!/{folder + "/" if folder else ""}storage/" && '
             f'git checkout "{version}"'
         ])
         logging.info(f'$ git shallow sparse clone {repository_url} of branch {version}')

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -199,6 +199,7 @@ class Client:
             logging.error(error)
             return False
 
+        # Cloning the project repository.
         self.world = filename
         mkdir_p(self.project_instance_path)
         os.chdir(self.project_instance_path)
@@ -207,19 +208,18 @@ class Client:
             path = os.getcwd()
         except OSError:
             path = False
-        print(f'cwd: {self.project_instance_path}')
-        # We only clone the given version of the repository.
-        # We checkout everything except the storage folder to speed up the clone.
+        # We use sparse checkout when the world file is inside a subfolder of the repository.
         if folder:
             sparse_set_command = f'git sparse-checkout set "/{folder}"'
         else:
-            sparse_set_command = 'echo "No need to set sparse checkout"'
+            sparse_set_command = 'echo "Cloning the whole repository, no need to set sparse checkout"'
+        # We only clone the given branch/tag of the repository.
         command = AsyncProcess([
             'bash', '-c',
             f'git clone --depth=1 --no-checkout --branch "{version}" "{repository_url}" && '
             f'cd "{repository}" && {sparse_set_command} && git checkout "{version}"'
         ])
-        logging.info(f'$ git shallow sparse clone {repository_url} of branch {version}')
+        logging.info(f'$ shallow and sparse git clone in repository {repository_url} on branch {version}')
         while True:
             output = command.run()
             if output[0] == 'x':

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -226,10 +226,11 @@ class Client:
         # command = AsyncProcess(['svn', 'export', url])
         # TODO: use git sparse-checkout instead of svn
         command = AsyncProcess([
-            'git', 'clone', '--depth=1', '--no-checkout', '--branch', version, repository_url, '&&',
-            'cd', repository, '&&',
-            'git', 'sparse-checkout', 'set', '/*', '!/storage/', '&&',
-            'git', 'checkout', version
+            'bash', '-c',
+            f'git clone --depth=1 --no-checkout --branch {version} {repository_url} && '
+            f'cd {repository} && '
+            'git sparse-checkout set /* !/storage/ && '
+            f'git checkout {version}'
         ])
         logging.info(f'$ git shallow sparse clone {repository_url} of branch {version}')
         while True:

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -229,7 +229,7 @@ class Client:
             'bash', '-c',
             f'git clone --depth=1 --no-checkout --branch {version} {repository_url} && '
             f'cd {repository} && '
-            'git sparse-checkout set /* !/storage/ && '
+            'git sparse-checkout set "/*" "!/storage/" && '
             f'git checkout {version}'
         ])
         logging.info(f'$ git shallow sparse clone {repository_url} of branch {version}')

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -246,9 +246,10 @@ class Client:
         if project == '':
             if version != default_branch:
                 project = '/' + version
-            else:
-                project = '/' + repository"""
+            else:"""
+        project = '/' + repository
         self.project_instance_path += project
+        print(f'self.project_instance_path: {self.project_instance_path}')
         logging.info('Done')
         if path:
             os.chdir(path)

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -211,9 +211,9 @@ class Client:
         # We only clone the given version of the repository.
         # We checkout everything except the storage folder to speed up the clone.
         if folder:
-            sparse_set_command = f'git sparse-checkout set "/{folder}" "!/{folder}/storage/" && '
+            sparse_set_command = f'git sparse-checkout set "/{folder}" "!/{folder}/storage/"'
         else:
-            sparse_set_command = 'git sparse-checkout set "/*" "!/storage/" && '
+            sparse_set_command = 'git sparse-checkout set "/*" "!/storage/"'
         command = AsyncProcess([
             'bash', '-c',
             f'git clone --depth=1 --no-checkout --branch "{version}" "{repository_url}" && '


### PR DESCRIPTION
GitHub is [sunsetting Subversion support](https://github.blog/2023-01-20-sunsetting-subversion-support/) for their repositories. In this PR, the svn export of GitHub projects was replaced with a shallow and sparse git clone. 

The sparse clone is needed when cloning a subfolder of a GitHub project.

It can be tested on https://benchmark.webots.cloud/:
- [Project](https://benchmark.webots.cloud/run?version=R2022b&url=https://github.com/cyberbotics/webots-cloud-simulation-examples/blob/main/3_robot_window/worlds/thymio_obstacle_avoidance.wbt&type=demo) in a subfolder of the repository
- [Project](https://benchmark.webots.cloud/run?version=R2023b&url=https%3A%2F%2Fgithub.com%2FJean-Eudes-le-retour%2Frobot-programming-benchmark%2Fblob%2Fmain%2Fworlds%2Frobot_programming.wbt&type=competition&context=try) at the root of the repository registered with a branch
- [Project](https://benchmark.webots.cloud/run?version=R2023b&url=https%3A%2F%2Fgithub.com%2FJean-Eudes-le-retour%2Frobot-programming-benchmark%2Fblob%2Fv1%2Fworlds%2Frobot_programming.wbt&type=competition&context=try) registered with a tag