### PR TITLE
Updated Docker Compose to V2

### DIFF
--- a/simulation_server.py
+++ b/simulation_server.py
@@ -398,7 +398,7 @@ class Client:
                 if client.webots_process is None:
                     break
                 line = line.rstrip()
-                if line.startswith(f'{str(id(self))}webots-1'):  # output from docker-compose's webots service
+                if line.startswith(f'{str(id(self))}-webots-1'):  # output from docker-compose's webots service
                     output = line[line.index('|') + 2:]
                     if output == '.':
                         client.websocket.write_message('.')

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -408,7 +408,7 @@ class Client:
                         client.idle = False
                     elif client.competition and output == 'reset':
                         subprocess.Popen([
-                            'docker compose', '-f', f'{self.project_instance_path}/docker-compose.yml',
+                            'docker', 'compose', '-f', f'{self.project_instance_path}/docker-compose.yml',
                             'restart', '--timeout', '0', 'controller'])
             client.on_exit()
 
@@ -866,6 +866,7 @@ def main():
     if config['docker']:
         if 'SSH_CONNECTION' not in os.environ:
             os.system('xhost +local:root')
+        os.environ['DOCKER_BUILDKIT'] = '0'  # buildkit is enabled by default in docker compose V2
     if 'webotsHome' not in config:
         config['webotsHome'] = os.getenv('WEBOTS_HOME', '/usr/bin/webots').replace('\\', '/')
     if config['docker']:

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -384,7 +384,7 @@ class Client:
                                 f"loading: Error: Image version {version} not available on Cyberbotics' dockerHub. "
                                 f"Please, add the appropriate Dockerfile to your project.")
                             return
-                    if '|' in line:  # docker-compose format
+                    if '|' in line:  # docker compose format
                         line = line[line.index('|') + 2:]
                 if line.startswith('.'):  # Webots world is loaded, ready to receive connections
                     logging.info('Webots world is loaded, ready to receive connections')

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -398,7 +398,7 @@ class Client:
                 if client.webots_process is None:
                     break
                 line = line.rstrip()
-                if line.startswith(f'{str(id(self))}-webots-1'):  # output from docker-compose's webots service
+                if line.startswith(f'{str(id(self))}-webots-1'):  # output from docker compose's webots service
                     output = line[line.index('|') + 2:]
                     if output == '.':
                         client.websocket.write_message('.')

--- a/simulation_server.py
+++ b/simulation_server.py
@@ -351,7 +351,7 @@ class Client:
                     for key, value in envVarDocker.items():
                         env_file.write(f'{key}={value}\n')
 
-                command = f'docker-compose -f {self.project_instance_path}/docker-compose.yml up --build --no-color'
+                command = f'docker compose -f {self.project_instance_path}/docker-compose.yml up --build --no-color'
             else:
                 webotsCommand += world
                 command = webotsCommand
@@ -398,7 +398,7 @@ class Client:
                 if client.webots_process is None:
                     break
                 line = line.rstrip()
-                if line.startswith('webots_1'):  # output from docker-compose's webots service
+                if line.startswith(f'{str(id(self))}webots-1'):  # output from docker-compose's webots service
                     output = line[line.index('|') + 2:]
                     if output == '.':
                         client.websocket.write_message('.')
@@ -408,7 +408,7 @@ class Client:
                         client.idle = False
                     elif client.competition and output == 'reset':
                         subprocess.Popen([
-                            'docker-compose', '-f', f'{self.project_instance_path}/docker-compose.yml',
+                            'docker compose', '-f', f'{self.project_instance_path}/docker-compose.yml',
                             'restart', '--timeout', '0', 'controller'])
             client.on_exit()
 
@@ -430,7 +430,7 @@ class Client:
         """Force the termination of Webots or relative Docker service(s)."""
         if config['docker']:
             if os.path.exists(f"{self.project_instance_path}/docker-compose.yml"):
-                os.system(f"docker-compose -f {self.project_instance_path}/docker-compose.yml down "
+                os.system(f"docker compose -f {self.project_instance_path}/docker-compose.yml down "
                           "-v --timeout 0")
 
             if self.webots_process:


### PR DESCRIPTION
Docker is [deprecating Docker Compose V1](https://docs.docker.com/compose/compose-v2/) at the end of June 2023. In this PR, the code is updated to work with the new format.

Most of the changes are just to change `docker-compose` into `docker compose` but the format of some of the outputs also slightly change. Docker Compose V2 uses buildkit by default.

The WebotsJS progress bar [rely on the format of the output](https://github.com/cyberbotics/webots/blob/master/resources/web/wwi/Server.js#L96-L108) which is modified by buildkit, so there is two way of dealing with this:
- We modify Webots's `Server.js` to be compatible with the new formats
- We disable buildkit

Currently, the second option seems better because there is also another issue with buildkit currently [not supporting symlink Dockerfiles](https://github.com/moby/buildkit/issues/2119). We need this as we create a Dockerfile symlink from a template if there is no Dockerfile in the project folder.

It would also be easier as we just need to set a environment variable to disable buildkit

Can be tested on simulations and competitions from the test server: https://testing.webots.cloud or https://benchmark.webots.cloud