### PR TITLE
Edits to work with new controller Dockerfile

### DIFF
--- a/config/simulation/docker/docker-compose-competition.yml
+++ b/config/simulation/docker/docker-compose-competition.yml
@@ -40,7 +40,7 @@ services:
       context: ./controllers
       dockerfile: Dockerfile
       args:
-        - WEBOTS_CONTROLLER_URL=ipc://$PORT/participant
+        - WEBOTS_CONTROLLER_URL=participant
         - PROJECT_PATH=$PROJECT_PATH
     command: python3 /usr/local/remote_controller_launcher.py
     deploy:
@@ -49,12 +49,13 @@ services:
           devices:
             - capabilities:
                 - gpu
-    tty: true # Allows the controller to send its output to Webots' console
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=all
       - WEBOTS_STDOUT_REDIRECT=1
       - WEBOTS_STDERR_REDIRECT=1
+      - PORT=$PORT
+    tty: true # Allows the controller to send its output to Webots' console
     volumes:
       - /dev/dri:/dev/dri:rw
       - /tmp/webots-$PORT/ipc/participant:/tmp/webots-$PORT/ipc/participant:rw


### PR DESCRIPTION
In this PR, the Docker Compose file for the competition is modified to work with the new format for the competition template (https://github.com/cyberbotics/competition-template/pull/20).

The `--port` argument of the new `webots-controller` launcher is given in a environment variable.

The new docker compose file can be tested on the test server here: https://benchmark.webots.cloud/run?version=R2023b&url=https%3A%2F%2Fgithub.com%2FJean-Eudes-le-retour%2FPersonal-compet-test%2Fblob%2Fmain%2Fworlds%2Frobot_programming.wbt&type=competition&context=try

The CI test logs can be found here: https://github.com/Jean-Eudes-le-retour/Personal-compet-test/actions/runs/4418046213/jobs/7744620510