### PR TITLE
Remove obsolete version from docker-compose file

### DIFF
--- a/config/simulation/docker/docker-compose-competition.yml
+++ b/config/simulation/docker/docker-compose-competition.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 volumes:
   controller_data:
 

--- a/config/simulation/docker/docker-compose-debug.yml
+++ b/config/simulation/docker/docker-compose-debug.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   webots:
     build:

--- a/config/simulation/docker/docker-compose-default.yml
+++ b/config/simulation/docker/docker-compose-default.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   webots:
     build:

--- a/config/simulation/docker/docker-compose-theia.yml
+++ b/config/simulation/docker/docker-compose-theia.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 volumes:
   controller_data:
 


### PR DESCRIPTION
Since docker version 25.05 the version in docker-compose.yml is be obsolete and is causing a warning.